### PR TITLE
#17: Defect status now considers duplicates and all kinds of bad links.

### DIFF
--- a/doc/system_requirements.md
+++ b/doc/system_requirements.md
@@ -52,12 +52,12 @@ The description contains the normative part of the specification.
 
 The rationale explains the reasoning behind a requirement or decision.
 
-The "Covers" section contains a list of all specification items that are covered by this item.
+The "Covers" section contains a list of all specification item IDs that are covered by this item.
 
-The "Depends" section contains a list of all specification items that must be implemented in order
+The "Depends" section contains a list of all specification item IDs that must be implemented in order
 for this item to be complete.
 
-The "Needs" section list all specification item types in which coverage for this item is needed.
+The "Needs" section list all artifact item types in which coverage for this item is needed.
 
 Needs: dsn
 
@@ -69,12 +69,12 @@ OFT determines the status of an outgoing coverage link of a specification item.
 
 The possible results are:
 
-  1. Covers:    coverage requester the link points to wants this coverage
-  2. Outdated:  coverage requester the link points to has a higher revision number
-  3. Predated:  coverage requester the link points to has a lower revision number
+  1. Covers:    link points to a specification item which wants this coverage
+  2. Outdated:  link points to a specification item which has a higher revision number
+  3. Predated:  link points to a specification item which has a lower revision number
   4. Ambiguous: link points to a specification item that has duplicates
-  5. Unwanted:  coverage  provider has an artifact type the provider does not want
-  6. Orphaned:  link is broken - there is no matching coverage  requester
+  5. Unwanted:  coverage provider has an artifact type the provider does not want
+  6. Orphaned:  link is broken - there is no matching coverage requester
 
 Covers:
 
@@ -104,7 +104,7 @@ Needs: dsn
 ### Deep Coverage
 `req~deep_coverage~1` <a id="req~deep_coverage~1`></a>
 
-OFT marks a specification item as _covered deeply_ if this items and all items it needs coverage from are covered recursively.
+OFT marks a specification item as _covered deeply_ if this item and all items it needs coverage from are covered recursively.
 
 Covers:
 
@@ -125,7 +125,7 @@ Covers:
 
 OFT marks a specification item as _defect_ if any of the following criteria apply
 
-  1. The specification item has duplicates
+  1. The specification item has duplicates (i.e. another specification item with the same ID exists)
   2. At least one outgoing coverage link has a different status than "Covers"
   3. The item is not covered deeply
   

--- a/doc/system_requirements.md
+++ b/doc/system_requirements.md
@@ -28,45 +28,9 @@ Needs: req
 
 # High Level Requirements
 
-## Needed Coverage Status
-`req~needed_coverage_status~1` <a id="req~needed_coverage_status~1"></a>
+## Anatomy of Specification Items
 
-OFT determines the status of the needed coverage of a specification item.
-
-The possible results are:
-
-  1. OK:        a specification item requires coverage and is covered by one or more other specification items
-  2. Uncovered: an specification item requires coverage but is not covered
-  3. Outdated:  coverage exists but points to a lower revision number of the requester
-  4. Predated:  coverage exists but points to a higher revision number of the requester
-
-Covers:
-
-  * [feat~requirement_tracing~1](#feat~requirement_tracing~1)
-
-Needs: dsn
-
-## Backward Coverage Status
-`req~backward_coverage_status~1` <a id="req~backward_coverage_status~1"></a>
-
-OFT determines the Backward coverage status of a requirement. "Backward" means that the links towards the requester are checked from the perspective of the item that provider.
-
-The possible results are:
-
-  1. Ok
-  2. Unwanted:  the covered item exists (in any revision) but wants to be covered in a different artifact type
-  3. Orphaned:  the provider claims to cover a non-existent requester
-  4. Outdated:  the provider covers a lower revision number than the requester actually has
-  5. Predated:  the provider covers a higher revision number than the requester actually has
-  6. Ambiguous: the covered item has one or more duplicates (in any revision)
-
-Covers:
-
-  * [feat~requirement_tracing~1](#feat~requirement_tracing~1)
-
-Needs: dsn
-
-## Specification Item
+### Specification Item
 `req~specification_item~1` <a id="req~specification_item~1"></a>
 
 A specification item consists of the following parts:
@@ -97,7 +61,80 @@ The "Needs" section list all specification item types in which coverage for this
 
 Needs: dsn
 
-## Input file selection
+### Outgoing Coverage Link Status
+`req~outgoing_coverage_link_status~1` <a id="req~outgoing_coverage_link_status~1"></a>
+
+_Outgoing coverage link_ means links that originate from a specification item and end at another specification item. 
+OFT determines the status of an outgoing coverage link of a specification item.
+
+The possible results are:
+
+  1. Covers:    coverage requester the link points to wants this coverage
+  2. Outdated:  coverage requester the link points to has a higher revision number
+  3. Predated:  coverage requester the link points to has a lower revision number
+  4. Ambiguous: link points to a specification item that has duplicates
+  5. Unwanted:  coverage  provider has an artifact type the provider does not want
+  6. Orphaned:  link is broken - there is no matching coverage  requester
+
+Covers:
+
+  * [feat~requirement_tracing~1](#feat~requirement_tracing~1)
+
+Needs: dsn
+
+### Incoming Coverage Link Status
+`req~incoming_coverage_link_status~1` <a id="req~incoming_coverage_link_status~1"></a>
+
+_Incoming coverage link_ means links that end at a specification item and originate at another specification item
+OFT determines the incoming coverage link status of a requirement.
+
+The possible results are:
+
+  1. Covered shallow:  coverage provider for a required coverage exists
+  2. Covered unwanted: coverage provider covers an artifact type the requester does not want
+  3. Covered predated: coverage provider covers a higher revision number than the requester has
+  4. Covered outdated: coverage provider covers a lower revision number than the requester has
+
+Covers:
+
+  * [feat~requirement_tracing~1](#feat~requirement_tracing~1)
+
+Needs: dsn
+
+### Deep Coverage
+`req~deep_coverage~1` <a id="req~deep_coverage~1`></a>
+
+OFT marks a specification item as _covered deeply_ if this items and all items it needs coverage from are covered recursively.
+
+Covers:
+
+  * [feat~requirement_tracing~1](#feat~requirement_tracing~1)
+
+### Duplicate Items
+`req~duplicate_items~1` <a id="req~duplicate_items~1></a>
+
+OFT marks a specification item as a _duplicate_ if other items with the same ID exist.
+
+Covers:
+
+  * [feat~requirement_tracing~1](#feat~requirement_tracing~1)
+
+
+### Defect Items
+`req~defect_items~1` <a id="req~defect_items~1"></a>
+
+OFT marks a specification item as _defect_ if any of the following criteria apply
+
+  1. The specification item has duplicates
+  2. At least one outgoing coverage link has a different status than "Covers"
+  3. The item is not covered deeply
+  
+Covers:
+
+  * [feat~requirement_tracing~1](#feat~requirement_tracing~1) 
+
+## Import
+### Input File Selection
 `req~input_file_selection~1` <a id="req~input_file_selection~1"></a>
 
 Users select the input files either directly or indirectly via directories. In case users give directories, all files below each directory and sub-directories are used as input.
@@ -112,7 +149,7 @@ Covers:
 
 Needs: dsn
 
-## Markdown Import
+### Markdown Import
 `req~markdown_import~1` <a id="req~markdown_import~1"></a>
 
 OFT imports specification items from Markdown.
@@ -135,7 +172,7 @@ Covers:
 
 Needs: dsn
 
-### Markdown Standard syntax
+#### Markdown Standard Syntax
 `req~markdown_standard_syntax~1` <a id="req~markdown_standard_syntax~1"></a>
 
 The OFT Markdown specification artifact format uses the standard markdown syntax without proprietary extensions.
@@ -150,7 +187,7 @@ Covers:
 
 Needs: dsn
 
-### Markdown Outline Readable
+#### Markdown Outline Readable
 The Markdown outline -- a table of contents created from the heading structure by various Markdown editors -- must be human readable.
 
 Rationale:

--- a/src/main/java/openfasttrack/core/LinkStatus.java
+++ b/src/main/java/openfasttrack/core/LinkStatus.java
@@ -24,6 +24,20 @@ package openfasttrack.core;
 
 public enum LinkStatus
 {
-    COVERS, UNWANTED, PREDATED, OUTDATED, AMBIGUOUS, DUPLICATE, ORPHANED, //
-    COVERED_SHALLOW, COVERED_UNWANTED, COVERED_PREDATED, COVERED_OUTDATED
+    // Outgoing coverage link status
+    COVERS, PREDATED, OUTDATED, AMBIGUOUS, UNWANTED, ORPHANED, //
+    // Incoming coverage link status
+    COVERED_SHALLOW, COVERED_UNWANTED, COVERED_PREDATED, COVERED_OUTDATED, //
+    // Duplicate link status
+    DUPLICATE;
+
+    /**
+     * Check if this is a bad link status.
+     * 
+     * @return <code>true</code> if the link status is bad.
+     */
+    public boolean isBad()
+    {
+        return (this != COVERS) && (this != COVERED_SHALLOW);
+    }
 }

--- a/src/main/java/openfasttrack/core/LinkedSpecificationItem.java
+++ b/src/main/java/openfasttrack/core/LinkedSpecificationItem.java
@@ -182,13 +182,26 @@ public class LinkedSpecificationItem
     }
 
     /**
-     * Check if the item is clean (i.e. covered deeply and not having any broken
-     * links)
+     * Check if the item is defect.
+     * 
+     * An item counts a defect if one of the following applies:
+     * <ul>
+     * <li>The item has offending links (broken coverage, duplicates)</li>
+     * <li>The item is not covered deeply
+     * <li>
+     * </ul>
      *
-     * @return <code>true</code> if the item is clean.
+     * @return <code>true</code> if the item is defect.
      */
-    public boolean isOk()
+    public boolean isDefect()
     {
-        return isCoveredDeeply();
+        for (final LinkStatus status : this.links.keySet())
+        {
+            if (status.isBad())
+            {
+                return true;
+            }
+        }
+        return !isCoveredDeeply();
     }
 }

--- a/src/main/java/openfasttrack/report/PlainTextReport.java
+++ b/src/main/java/openfasttrack/report/PlainTextReport.java
@@ -134,7 +134,7 @@ public class PlainTextReport implements Reportable
 
     private void reportItemDetails(final LinkedSpecificationItem item, final PrintStream report)
     {
-        report.print(translateStatus(item.isOk()));
+        report.print(translateStatus(!item.isDefect()));
         report.print(" - ");
         report.println(item.getId().toString());
         for (final String line : item.getDescription().split("\n"))

--- a/src/test/java/openfasttrack/report/TestPlainTextReport.java
+++ b/src/test/java/openfasttrack/report/TestPlainTextReport.java
@@ -152,17 +152,14 @@ public class TestPlainTextReport
 
     private String expectFailureDetails()
     {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("not ok - dsn~bar~1\n") //
-                .append("# desc B1\n") //
-                .append("not ok - req~foo~1\n") //
-                .append("# desc A1\n# desc A2\n# desc A3\n") //
-                .append("not ok - req~zoo~1\n") //
-                .append("# desc D1\n") //
-                .append("not ok - req~zoo~2\n") //
-                .append("# desc C1\n# desc C2\n") //
-                .append("\nnot ok - 6 total, 4 not covered\n");
-
-        return builder.toString();
+        return "not ok - dsn~bar~1\n" //
+                + "# desc B1\n" //
+                + "not ok - req~foo~1\n" //
+                + "# desc A1\n# desc A2\n# desc A3\n" //
+                + "not ok - req~zoo~1\n" //
+                + "# desc D1\n" //
+                + "not ok - req~zoo~2\n" //
+                + "# desc C1\n# desc C2\n" //
+                + "\nnot ok - 6 total, 4 not covered\n";
     }
 }

--- a/src/test/java/openfasttrack/report/TestPlainTextReport.java
+++ b/src/test/java/openfasttrack/report/TestPlainTextReport.java
@@ -124,22 +124,6 @@ public class TestPlainTextReport
         assertThat(getReportOutput(ReportVerbosity.FAILURE_DETAILS), equalTo(expected));
     }
 
-    private String expectFailureDetails()
-    {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("not ok - dsn~bar~1\n") //
-                .append("# desc B1\n") //
-                .append("not ok - req~foo~1\n") //
-                .append("# desc A1\n# desc A2\n# desc A3\n") //
-                .append("not ok - req~zoo~1\n") //
-                .append("# desc D1\n") //
-                .append("not ok - req~zoo~2\n") //
-                .append("# desc C1\n# desc C2\n") //
-                .append("\nnot ok - 6 total, 4 not covered\n");
-
-        return builder.toString();
-    }
-
     private void prepareFailedItemDetails()
     {
         final LinkedSpecificationItem itemAMock = mock(LinkedSpecificationItem.class);
@@ -158,7 +142,27 @@ public class TestPlainTextReport
         when(itemBMock.getDescription()).thenReturn("desc B1");
         when(itemCMock.getDescription()).thenReturn("desc C1\ndesc C2");
         when(itemDMock.getDescription()).thenReturn("desc D1");
+        when(itemAMock.isDefect()).thenReturn(true);
+        when(itemBMock.isDefect()).thenReturn(true);
+        when(itemCMock.isDefect()).thenReturn(true);
+        when(itemDMock.isDefect()).thenReturn(true);
         when(this.traceMock.getUncoveredItems())
                 .thenReturn(Arrays.asList(itemAMock, itemBMock, itemCMock, itemDMock));
+    }
+
+    private String expectFailureDetails()
+    {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("not ok - dsn~bar~1\n") //
+                .append("# desc B1\n") //
+                .append("not ok - req~foo~1\n") //
+                .append("# desc A1\n# desc A2\n# desc A3\n") //
+                .append("not ok - req~zoo~1\n") //
+                .append("# desc D1\n") //
+                .append("not ok - req~zoo~2\n") //
+                .append("# desc C1\n# desc C2\n") //
+                .append("\nnot ok - 6 total, 4 not covered\n");
+
+        return builder.toString();
     }
 }


### PR DESCRIPTION
This is needed to determine if an item is defect or not.